### PR TITLE
fix: show file service log when enabled

### DIFF
--- a/lib/node/file/file.service.ts
+++ b/lib/node/file/file.service.ts
@@ -26,9 +26,13 @@ export class FileService {
     async writeFileAsync(fileNameWithoutExtension: string, content: any): Promise<void> {
         const filePath = this.getFilePath(fileNameWithoutExtension);
 
-        console.log(`Writing file '${filePath}'`);
+        if (this.config.enableLog) {
+            console.log(`Writing file '${filePath}'`);
+        }
         await promises.writeFile(filePath, content);
-        console.log(`File saved`);
+        if (this.config.enableLog) {
+            console.log(`File saved`);
+        }
     }
 
     private getFilePath(fileNameWithoutExtension: string) {


### PR DESCRIPTION
### Motivation

Part of the `lib/node/file.service.ts` was not checking for `enableLog` before using `console.log`.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Use the `FileService` in code, with the `enableLog` set to `false`, it will still log for the "writing" step.
