### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Kontent Backup Manager
 
-The purpose of this project is to backup & restore [Kentico Kontent](https://kontent.ai) projects. This project uses CM API to both get & restore data.
+The purpose of this project is to backup & restore [Kentico Kontent](https://kontent.ai) projects. This project uses Management API to both get & restore data.
 
 ## Installation
 
@@ -73,7 +73,7 @@ Create a `json` configuration file in the folder where you are attempting to run
     "enableLog": true,
     "force": true,
     "baseUrl": null,
-    "exportFilter: null
+    "exportFilter": null
 }
 ```
 


### PR DESCRIPTION
### Motivation

Fixes two typos I noticed in the readme when going through it to check for old URLs as part of https://kentico.atlassian.net/browse/CTC-1518.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
